### PR TITLE
Update eventtypes.conf

### DIFF
--- a/default/eventtypes.conf
+++ b/default/eventtypes.conf
@@ -1,11 +1,8 @@
 [ms-windefender-operation]
 search = source="*WinEventLog:*Defender*" NOT category IN ("detection")
-tags = malware operations
 
 [ms-windefender-attack]
 search = source="*WinEventLog:*Defender*" category IN ("detection")
-tags = malware attack
 
 [ms-windefender-alert]
 search = source="*WinEventLog:*Defender*" category IN ("detection") AND action IN ("deferred", "allowed")
-tags = alert


### PR DESCRIPTION
tags are deprecated in eventtypes.conf
see:
https://docs.splunk.com/Documentation/Splunk/latest/Admin/Eventtypesconf

tags = <string>
* DEPRECATED - see tags.conf.spec