### PR TITLE
Update props.conf

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -31,7 +31,7 @@ EVAL-datetime = strptime(replace(SystemTime,"'",""), "%Y-%m-%dT%H:%M:%S.%fZ")
 # [X] ALERT     action - The action taken by the IDS (allowed, blocked)
 # [X] MALWARE   action - The action taken by the reporting device (allowed, blocked, deferred)
 LOOKUP-0Action_ID = windefender_action_lookup Action_ID OUTPUTNEW Action_Name,action
-LOOKUP-CategoryString_for_windows = windefender_signature_lookup signature_id OUTPUTNEW action, CategoryString AS category, result, signature, subsystem
+LOOKUP-CategoryString_for_windows = windefender_signature_lookup signature_id OUTPUTNEW action, CategoryString AS category, result, signature AS signature_id_description, subsystem
 # FIELDALIAS-category = CategoryString AS category
 # [X] ALERT     category - The vendor-provided category of the triggered signature, such as spyware.
 # [X] MALWARE   category - The category of the malware event, such as keylogger or ad-supported program
@@ -98,6 +98,7 @@ LOOKUP-severity = windefender_severity_lookup Severity_ID OUTPUT Severity_Name,s
 # ! Attention: Reset signature in datamodel creation query and leave as is for windows logging compliance
 EVAL-threat_name = Threat_Name
 EVAL-signature_version = Current_Signature_Version
+EVAL-signature = Threat_Name
 
 # [ ] ALERT     transport - The OSI layer 4 (transport) protocol of the intrusion, in lower case.
 


### PR DESCRIPTION
In the "windefender_signature_lookup" the "signature" field should output as a "signature_id_description" to avoid overwriting the "signature" field that is recommended for the Malware DataModel:

https://docs.splunk.com/Documentation/CIM/5.2.0/User/Malware

"The name of the malware infection detected on the client (the dest)."